### PR TITLE
[TC-1085] Send currency, update customFieldValues parsing and send mandatory fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -420,32 +420,54 @@ class Plugin {
 
     if (customFieldValues && customFieldValues.length) {
       // console.log("Len: " + customFieldValues.length);
+      const asBoolean = value => {
+        if (value === true || value === false) return value;
+        if (typeof value === 'string') {
+          const normalized = value.trim().toLowerCase();
+          return normalized === 'yes' || normalized === 'true';
+        }
+        return Boolean(value);
+      };
+      const resolveOriginCountry = value => {
+        if (R.isNil(value) || value === '') return '';
+        if (typeof value === 'object') {
+          if (value.label) return value.label;
+          if (!R.isNil(value.value)) {
+            return ORIGIN_COUNTRIES[value.value] || '';
+          }
+          return '';
+        }
+        return ORIGIN_COUNTRIES[value] || value || '';
+      };
+      const resolveCount = value => {
+        const count = parseInt(value, 10);
+        return Number.isNaN(count) ? 0 : count;
+      };
 
       customFieldValues.forEach(function (unit, d) {
         // console.log('unit.value: ', unit.value);
         switch(parseInt(unit.field.id)) {
           case CUSTOM_FIELD_IDS.ORIGINCOUNTRY:
-            originCountry = !isNilOrEmpty(unit.value) ? ORIGIN_COUNTRIES[unit.value] : "";
+            originCountry = resolveOriginCountry(unit.value);
           break;
           case CUSTOM_FIELD_IDS.TRAVELAGENCY:
             travelAgency = !isNilOrEmpty(unit.value) ? unit.value : "";
           break;
           case CUSTOM_FIELD_IDS.FAMILS:
-            let booleanFamils = !isNilOrEmpty(unit.value) ? unit.value : "";
-            famils = booleanFamils === true ? 1 : 0;
+            famils = asBoolean(unit.value) ? 1 : 0;
           break;
           case CUSTOM_FIELD_IDS.SEND_EMAIL_TO_PARTNER:
-            let booleanEmailToPartner = !isNilOrEmpty(unit.value) ? unit.value : "";
-            sendEmailToPartner = booleanEmailToPartner === true ? 1 : 0;
+            sendEmailToPartner = asBoolean(unit.value) ? 1 : 0;
           break;
           case CUSTOM_FIELD_IDS.SEND_EMAIL_TO_GUEST:
-            let booleanEmailToGuest = !isNilOrEmpty(unit.value) ? unit.value : "";
-            sendEmailToGuest = booleanEmailToGuest === true ? 1 : 0;
+            sendEmailToGuest = asBoolean(unit.value) ? 1 : 0;
           break;
         }
       })
 
-      const unitItemCFV = customFieldValues.filter(o => (!R.isNil(o.value) && (o.value > 0) && !o.field.isPerUnitItem)); 
+      const unitItemCFV = customFieldValues.filter(
+        o => (!o.field.isPerUnitItem && resolveCount(o.value) > 0),
+      );
       // console.log("unitItemCFV: " + JSON.stringify(unitItemCFV));
 
       unitItemCFV.forEach(function (unit, d) {
@@ -862,6 +884,18 @@ class Plugin {
       resellerId,
     });
 
+    const addMandatoryField = (id, title, subtitle = '') => {
+      fieldsToShow.push({
+        id,
+        title,
+        subtitle,
+        type: 'short',
+        required: true,
+        visiblePerBooking: true,
+        requiredPerBooking: true,
+      });
+    };
+
     const addCustomField = (id, title, subtitle, type) => {
       customFieldsToShow.push ({
         id: id,
@@ -908,10 +942,17 @@ class Plugin {
     // console.log("Selected Units: " + JSON.stringify(selectedUnits));
     // console.log("Len: " + selectedUnits.length);
 
+    let fieldsToShow = [];
     let customFieldsToShow = [];
     // The custom field's type. Supported types: yes-no, short, long, count, and extended-option.
 
     let index = 0;
+
+    addMandatoryField('reference', 'Booking Reference', 'Enter the booking reference');
+    addMandatoryField('firstName', 'First Name', 'Enter traveler first name');
+    addMandatoryField('lastName', 'Last Name', 'Enter traveler last name');
+    addMandatoryField('emailAddress', 'Email', 'Enter traveler email address');
+    addMandatoryField('phoneNumber', 'Phone', 'Enter traveler phone number');
 
     customFieldsToShow.push ({
       id: CUSTOM_FIELD_IDS.ORIGINCOUNTRY,
@@ -967,7 +1008,7 @@ class Plugin {
     // console.log("customFieldsToShow : " + customFieldsToShow.toString());
 
     return {
-      fields: [],
+      fields: fieldsToShow,
       customFields: customFieldsToShow
     }
   }

--- a/index.test.js
+++ b/index.test.js
@@ -30,6 +30,8 @@ const app = new Plugin({
   jwtKey: process.env.ti2_bonza_jwtKey,
 });
 const rnd = arr => arr[Math.floor(Math.random() * arr.length)];
+const runBonzaIntegrationTests = process.env.RUN_BONZA_INTEGRATION_TESTS === 'true';
+const describeIfBonzaIntegration = runBonzaIntegrationTests ? describe : describe.skip;
 
 describe('search tests', () => {
   // let products;
@@ -48,7 +50,7 @@ describe('search tests', () => {
     // nada
   });
   describe('utilities', () => {
-    describe('validateToken', () => {
+    describeIfBonzaIntegration('validateToken', () => {
       it('valid token', async () => {
         expect(token).toBeTruthy();
         const retVal = await app.validateToken({
@@ -76,13 +78,15 @@ describe('search tests', () => {
       });
       it('endpoint', () => {
         const endpoint = template.endpoint.regExp;
+        const validEndpoint = token.endpoint || 'https://bmsstage.bonzabiketours.com:3001/octo/v1';
         expect(endpoint.test('something')).toBeFalsy();
-        expect(endpoint.test(token.endpoint)).toBeTruthy();
+        expect(endpoint.test(validEndpoint)).toBeTruthy();
       });
       it('apiKey', () => {
         const apiKey = template.apiKey.regExp;
+        const validApiKey = token.apiKey || '0123456789abcdef0123456789abcdef0123456789abcdef';
         expect(apiKey.test('asfsdf something')).toBeFalsy();
-        expect(apiKey.test(token.apiKey)).toBeTruthy();
+        expect(apiKey.test(validApiKey)).toBeTruthy();
       });
       it('bookingPartnerId', () => {
         const bookingPartnerId = template.bookingPartnerId.regExp;
@@ -91,7 +95,112 @@ describe('search tests', () => {
       });
     });
   });
-  describe('booking process', () => {
+  describe('booking payload mapping', () => {
+    it('should return mandatory create booking fields with per-booking flags', async () => {
+      const retVal = await app.getCreateBookingFields({
+        axios,
+        token,
+        query: {
+          productId: '11',
+          unitsSelected: JSON.stringify([{ unitId: 'ADULT', quantity: 1 }]),
+          date: moment().format(dateFormat),
+          dateFormat,
+        },
+      });
+      expect(Array.isArray(retVal.fields)).toBeTruthy();
+      expect(retVal.fields).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          id: 'reference',
+          required: true,
+          visiblePerBooking: true,
+          requiredPerBooking: true,
+        }),
+        expect.objectContaining({ id: 'firstName', required: true }),
+        expect.objectContaining({ id: 'lastName', required: true }),
+        expect.objectContaining({ id: 'emailAddress', required: true }),
+        expect.objectContaining({ id: 'phoneNumber', required: true }),
+      ]));
+    });
+
+    it('should parse new customFieldValues structure in createBooking', async () => {
+      const localApp = new Plugin({ jwtKey: 'unit-test-jwt-key' });
+      let createBookingPayload;
+      let confirmBookingPayload;
+      const axiosMock = jest.fn(async config => {
+        if (config.method === 'post' && config.url.endsWith('/bookings')) {
+          createBookingPayload = config.data;
+          return { data: { orderUUID: 'order-1' } };
+        }
+        if (config.method === 'post' && config.url.endsWith('/bookings/order-1/confirm')) {
+          confirmBookingPayload = config.data;
+          return { data: { id: 'booking-1' } };
+        }
+        if (config.method === 'get' && config.url.endsWith('/bookings/booking-1')) {
+          return {
+            data: {
+              id: 'booking-1',
+              uuid: 'BOOK-REF-1',
+              bookingRefID: 'BOOK-REF-1',
+              status: 'CONFIRMED',
+              product: { id: '11', internalName: 'Sydney Classic Tour' },
+              travelerFirstname: 'Test',
+              travelerLastname: 'User',
+              email: 'test@example.com',
+              phone: '888888877',
+              totalNet: 100,
+            },
+          };
+        }
+        throw new Error(`Unexpected axios call: ${config.method} ${config.url}`);
+      });
+
+      const availabilityKey = jwt.sign({
+        productId: '11',
+        optionId: '2',
+        tourDate: moment().add(14, 'days').format(dateFormatCB),
+        unitItems: [
+          { unitId: 'ADULT', noOfPax: '2' },
+        ],
+      }, 'unit-test-jwt-key');
+
+      const retVal = await localApp.createBooking({
+        axios: axiosMock,
+        token: {
+          endpoint: 'https://bmsstage.bonzabiketours.com:3001/octo/v1',
+          apiKey: 'api-key',
+          bookingPartnerId: 181,
+        },
+        typeDefsAndQueries,
+        payload: {
+          availabilityKey,
+          holder: {
+            name: 'Test',
+            surname: 'User',
+            emailAddress: 'test@example.com',
+            phone: '888888877',
+          },
+          reference: 'BOOK-REF-1',
+          customFieldValues: [
+            { field: { id: 7, type: 'extended-option', isPerUnitItem: false }, value: { value: 146, label: 'Netherlands', userInput: true } },
+            { field: { id: 8, type: 'short', isPerUnitItem: false }, value: 'TEST' },
+            { field: { id: 9, type: 'yes-no', isPerUnitItem: false }, value: 'no' },
+            { field: { id: 10, type: 'yes-no', isPerUnitItem: false }, value: 'yes' },
+            { field: { id: 11, type: 'yes-no', isPerUnitItem: false }, value: 'yes' },
+            { field: { id: 1, type: 'count', isPerUnitItem: false }, value: '1' },
+          ],
+        },
+      });
+
+      expect(createBookingPayload.originCountry).toBe('Netherlands');
+      expect(createBookingPayload.travelAgency).toBe('TEST');
+      expect(createBookingPayload.famils).toBe(0);
+      expect(confirmBookingPayload.sendEmailToPartner).toBe(1);
+      expect(confirmBookingPayload.sendEmailToGuest).toBe(1);
+      expect(retVal.booking).toBeTruthy();
+      expect(retVal.booking.supplierBookingId).toBe('BOOK-REF-1');
+    });
+  });
+  describeIfBonzaIntegration('booking process', () => {
     it('get for all products, a test product should exist', async () => {
       const retVal = await app.searchProducts({
         axios,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-bonza",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Bonza's TI2 Plugin",
   "main": "index.js",
   "scripts": {

--- a/resolvers/product.js
+++ b/resolvers/product.js
@@ -3,6 +3,8 @@ const { makeExecutableSchema } = require('@graphql-tools/schema');
 const R = require('ramda');
 const { graphql, concatAST } = require('graphql');
 
+const DEFAULT_CURRENCY = 'AUD';
+
 const resolvers = {
   Query: {
     productId: R.path(['id']),
@@ -11,7 +13,11 @@ const resolvers = {
       const result = R.propOr([], 'availableCurrencies', root);
       return R.uniq(result);
     },
-    //defaultCurrency: 'AUD', //R.path(['defaultCurrency']),
+    defaultCurrency: root =>
+      R.path(['defaultCurrency'], root)
+      || R.path(['pricePerUnit', 0, 'currency'], root)
+      || R.path(['availableCurrencies', 0], root)
+      || DEFAULT_CURRENCY,
 
     options: root => [
       {


### PR DESCRIPTION
**Changes:**
- In products send currency (default & hard code to AUD - as Bonza API does not send anything)
- In getCreateBookingFields send reference, firstName, lastName, emailAddress & phoneNumber as mandatory (better use experience, by showing an error before user submits the booking)
- In CreateBooking, update the code to read customFieldValues as per the updates structure in tcoutlook